### PR TITLE
Allow checking individual modules, add usage instructions.

### DIFF
--- a/readmecheck
+++ b/readmecheck
@@ -1,5 +1,19 @@
 #!/bin/bash
 
+# Verifies that modules contain README files with required sections:
+# Introduction, Requirements, Installation, and Configuration.
+
+function usage() {
+  cat <<EOF
+Check modules for README files.
+
+ Usage: $(basename "$0") path
+
+Arguments:
+ path: may be a specific module directory or a directory containing modules.
+EOF
+}
+
 function readme_check() {
     SUCCESS=0
     FILENAME="$1/README.md"
@@ -39,14 +53,28 @@ function readme_check() {
 
 SUCCESS=0
 
-for entry in "${1%/}"/*
+if [[ -z "$1" ]]; then
+  usage
+  exit 1
+fi
+
+entries=()
+basename=$(basename "$1")
+module_file="$1/${basename}.module"
+if [[ -f "${module_file}" ]]; then
+  entries+=("$1")
+else
+  entries=("${1%/}"/*)
+fi
+
+for entry in ${entries[*]}
 do
     if [ -d $entry ]
     then
         if ! readme_check "$entry"
         then
             SUCCESS=1
-        fi    
+        fi
     fi
 done
 


### PR DESCRIPTION
I wanted to check individual modules so I added a way to determine if the script's argument is a module instead of directory containing modules.

This allows me to add checks as more readmes are added without requiring an entire set of modules to have one.

Ie, I currently run
```
readmecheck sites/all/modules/custom
```

and would like to change that to

```
readmecheck sites/all/modules/custom
readmecheck sites/all/modules/_features/some_module
```

I added a usage function so if it's invoked without arguments you get some information about how it's used. As a side-effect, that fixes an issue where running `$ readmecheck` would check every sub-directory of `/` for readmes.

```
$ bash readmecheck
Check modules for README files.

 Usage: readmecheck path

Arguments:
 path: may be a specific module directory or a directory containing modules.
```

before, trying to check one module checks a module's subdirectories as if they're each a module.
```
$ bash readmecheck test
test/includes/README.md doesn't exist
test/src/README.md doesn't exist
test/tests/README.md doesn't exist
```

Now if the argument is a directory with a module file it looks at it directly.
```
$ bash readmecheck wwwroot/sites/all/modules/_features/some_module
wwwroot/sites/all/modules/_features/some_module/README.md doesn't contain an introduction
wwwroot/sites/all/modules/_features/some_module/README.md doesn't contain requirements
wwwroot/sites/all/modules/_features/some_module/README.md doesn't contain installation instructions
wwwroot/sites/all/modules/_features/some_module/README.md doesn't contain configuration instructions
```

and it behaves the same if the argument does not have a module file.
```
$ bash readmecheck test
test/a/README.md doesn't exist
test/b/README.md doesn't exist
```